### PR TITLE
Update setup.py with hmmlearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         "scipy",
         "numpy",
         "scikit-allel",
-        "pandas"
+        "pandas",
+        "hmmlearn"
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Added `hmmlearn` to the list of install requirements, because `snpmatch cross` won't run without it.